### PR TITLE
Update recipe generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ npm test
 - [X] [`/skins/resolve`](#skinsresolve)
 - [X] [`/skins/prices`](#skinsprices)
 - [X] [`/recipe/nested/:id`](#recipenestedid)
-- [ ] [`/recipe/cost/:ids`](#recipecostids)
 - [X] [`/gems/history`](#gemshistory)
 
 ### `/item/:id`
@@ -89,6 +88,10 @@ This endpoint returns a single item.
       "quantity": 16,
       "price": -140
     }
+  },
+  "crafting": {
+    "buy": 1337,
+    "sell": 4242
   },
   "last_update": "2015-06-09T05:55:44+0000"
 }
@@ -330,24 +333,6 @@ All components that can be crafted include their respective recipe and subcompon
     },
     // ...
   ]
-}
-```
-
-### `/recipe/cost/:ids`
-
-This endpoint returns the crafting costs for the given item ids. `craft_buy` is the price if you order the materials, `craft_sell` the price if you instantly buy the materials.
-
-**Parameters**
-
-- `ids`: An array or a comma separated list of one or more item ids, either in the url or as a GET/POST parameter
-
-```js
-{
-  "31083": {
-    "craft_buy": 123,
-    "craft_sell": 456
-  },
-  // ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ npm test
 
 ## Endpoints
 
-- [X] [`/item/:id`](#itemid)
-- [X] [`/items/:ids`](#itemsids)
-- [X] [`/items/all`](#itemsall)
-- [X] [`/items/all-prices`](#itemsall-prices)
-- [X] [`/items/autocomplete`](#itemsautocomplete)
-- [X] [`/items/by-name`](#itemsby-name)
-- [X] [`/items/by-skin`](#itemsby-skin)
-- [X] [`/items/query`](#itemsquery)
-- [X] [`/items/categories`](#itemscategories)
-- [X] [`/skins/resolve`](#skinsresolve)
-- [X] [`/skins/prices`](#skinsprices)
-- [X] [`/recipe/nested/:id`](#recipenestedid)
-- [X] [`/gems/history`](#gemshistory)
+- [`/item/:id`](#itemid)
+- [`/items/:ids`](#itemsids)
+- [`/items/all`](#itemsall)
+- [`/items/all-prices`](#itemsall-prices)
+- [`/items/autocomplete`](#itemsautocomplete)
+- [`/items/by-name`](#itemsby-name)
+- [`/items/by-skin`](#itemsby-skin)
+- [`/items/query`](#itemsquery)
+- [`/items/categories`](#itemscategories)
+- [`/skins/resolve`](#skinsresolve)
+- [`/skins/prices`](#skinsprices)
+- [`/recipe/nested/:id`](#recipenestedid)
+- [`/gems/history`](#gemshistory)
 
 ### `/item/:id`
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gw2e-async-promises": "^1.0.2",
     "gw2e-gw2api-client": "^1.0.0",
     "gw2e-gw2api-scraping": "^1.0.1",
-    "gw2e-recipe-nesting": "^1.0.0",
+    "gw2e-recipe-nesting": "^2.0.0",
     "gw2e-requester": "^1.0.0",
     "mongodb": "^2.1.7",
     "newrelic": "^1.25.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gw2e-async-promises": "^1.0.2",
     "gw2e-gw2api-client": "^1.0.0",
     "gw2e-gw2api-scraping": "^1.0.1",
+    "gw2e-recipe-calculation": "^1.0.1",
     "gw2e-recipe-nesting": "^2.0.0",
     "gw2e-requester": "^1.0.0",
     "mongodb": "^2.1.7",

--- a/src/workers/item.js
+++ b/src/workers/item.js
@@ -138,12 +138,14 @@ function transformPrices (item, prices) {
     buy: {
       quantity: prices.buys.quantity,
       price: prices.buys.unit_price,
-      last_change: lastPriceChange(item.buy, prices.buys)
+      last_change: lastPriceChange(item.buy, prices.buys),
+      last_known: prices.buys.unit_price || item.buy.price || item.buy.last_known
     },
     sell: {
       quantity: prices.sells.quantity,
       price: prices.sells.unit_price,
-      last_change: lastPriceChange(item.sell, prices.sells)
+      last_change: lastPriceChange(item.sell, prices.sells),
+      last_known: prices.sells.unit_price || item.sell.price || item.sell.last_known
     },
     last_update: isoDate()
   }

--- a/src/workers/item.js
+++ b/src/workers/item.js
@@ -134,7 +134,7 @@ function transformTradable (flags) {
 }
 
 function transformPrices (item, prices) {
-  return {
+  let transformed = {
     buy: {
       quantity: prices.buys.quantity,
       price: prices.buys.unit_price,
@@ -147,6 +147,13 @@ function transformPrices (item, prices) {
     },
     last_update: isoDate()
   }
+
+  if (item.crafting) {
+    let craftPrice = item.craftingWithoutPrecursors || item.crafting
+    transformed.craftingProfit = Math.round(transformed.sell.price * 0.85 - craftPrice.buy)
+  }
+
+  return transformed
 }
 
 function lastPriceChange (memory, current) {

--- a/src/workers/recipe.js
+++ b/src/workers/recipe.js
@@ -5,6 +5,10 @@ const api = require('../helpers/api.js')
 const requester = require('gw2e-requester')
 const async = require('gw2e-async-promises')
 const recipeNesting = require('gw2e-recipe-nesting')
+const recipeCalculation = require('gw2e-recipe-calculation')
+
+const legendaries = [30684, 30685, 30686, 30687, 30688, 30689, 30690, 30691, 30692, 30693, 30694, 30695, 30696, 30697, 30698, 30699, 30700, 30701, 30702, 30703, 30704, 71383, 72713, 76158]
+const precursors = [29166, 29167, 29168, 29169, 29170, 29171, 29172, 29173, 29174, 29175, 29176, 29177, 29178, 29179, 29180, 29181, 29182, 29183, 29184, 29185]
 
 async function initialize () {
   let recipesCollection = mongo.collection('recipe-trees')
@@ -16,10 +20,14 @@ async function initialize () {
 
   if (itemExists && !recipeExists) {
     await execute(loadRecipeList)
+    await execute(updateCraftingPrices)
   }
 
   // Update the recipes every day at 4
   schedule('0 0 4 * * *', loadRecipeList)
+
+  // Update the crafting prices every 5 minutes
+  schedule('*/5 * * * *', updateCraftingPrices)
 
   logger.info('Initialized recipe worker')
 }
@@ -48,6 +56,72 @@ async function loadRecipeList () {
   let craftableIds = recipes.map(r => r.id)
   await itemCollection.update({id: {'$nin': craftableIds}}, {'$set': {craftable: false}}, {multi: true})
   await itemCollection.update({id: {'$in': craftableIds}}, {'$set': {craftable: true}}, {multi: true})
+}
+
+function updateCraftingPrices () {
+  return new Promise(async resolve => {
+    let recipes = await mongo.collection('recipe-trees').find().toArray()
+    let prices = await mongo.collection('items').find(
+      {tradable: true, 'buy.price': {'$gt': 0}, 'sell.price': {'$gt': 0}},
+      {_id: 0, id: 1, 'buy.price': 1, 'sell.price': 1}
+    ).toArray()
+
+    // Build the price arrays
+    let sellPrices = {}
+    let buyPrices = {}
+    prices.map(item => {
+      buyPrices[item.id] = item.buy.price
+      sellPrices[item.id] = item.sell.price
+    })
+    buyPrices = recipeCalculation.useVendorPrices(buyPrices)
+    sellPrices = recipeCalculation.useVendorPrices(sellPrices)
+
+    // Go through the recipes and update the items with
+    // the cheapest crafting price
+    let collection = mongo.collection('items')
+    let updateFunctions = recipes.map(recipe => () =>
+      new Promise(async resolve => {
+        var item = {
+          crafting: calculateCraftingPrice(recipe, buyPrices, sellPrices)
+        }
+
+        // If the item is a legendary add an additional
+        // crafting object without precursor crafting
+        if (legendaries.indexOf(recipe.id) !== -1) {
+          item.craftingWithoutPrecursors = calculateCraftingPrice(recipe, buyPrices, sellPrices, precursors)
+        }
+
+        await collection.update({id: recipe.id}, {'$set': item}, {multi: true})
+        resolve()
+      })
+    )
+
+    await async.parallel(updateFunctions)
+    resolve()
+  })
+}
+
+function calculateCraftingPrice (recipe, buyPrices, sellPrices, ignoreItems = []) {
+  // Calculate the normal crafting prices
+  let prices = {
+    buy: recipeCalculation.cheapestTree(1, recipe, buyPrices, {}, ignoreItems).craftPrice,
+    sell: recipeCalculation.cheapestTree(1, recipe, sellPrices, {}, ignoreItems).craftPrice
+  }
+
+  // Calculate the crafting price without daily cooldowns
+  if (needsDailyCooldowns(recipe)) {
+    ignoreItems = ignoreItems.concat(recipeCalculation.static.buyableDailyCooldowns)
+    prices.buyNoDaily = recipeCalculation.cheapestTree(1, recipe, buyPrices, {}, ignoreItems).craftPrice
+    prices.sellNoDaily = recipeCalculation.cheapestTree(1, recipe, sellPrices, {}, ignoreItems).craftPrice
+  }
+
+  return prices
+}
+
+function needsDailyCooldowns (recipe) {
+  let items = recipeCalculation.recipeItems(recipe)
+  items = items.filter(i => i !== recipe.id && recipeCalculation.static.dailyCooldowns.indexOf(i) !== -1)
+  return items.length > 0
 }
 
 async function loadCustomRecipes () {
@@ -98,4 +172,4 @@ async function loadCustomRecipes () {
   return recipes
 }
 
-module.exports = {initialize, loadRecipeList}
+module.exports = {initialize, loadRecipeList, updateCraftingPrices}

--- a/tests/workers/item.spec.js
+++ b/tests/workers/item.spec.js
@@ -141,12 +141,14 @@ describe('workers > item worker', () => {
         buy: {
           quantity: 29731,
           price: 58,
-          last_change: {quantity: 0, price: 0, time: currentDate}
+          last_change: {quantity: 0, price: 0, time: currentDate},
+          last_known: 58
         },
         sell: {
           quantity: 42594,
           price: 133,
-          last_change: {quantity: 0, price: 0, time: currentDate}
+          last_change: {quantity: 0, price: 0, time: currentDate},
+          last_known: 133
         },
         last_update: currentDate,
         tradable: true
@@ -294,7 +296,8 @@ describe('workers > item worker', () => {
           time: currentDate,
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 18053
       },
       sell: {
         quantity: 56,
@@ -303,7 +306,8 @@ describe('workers > item worker', () => {
           time: currentDate,
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 48053
       },
       last_update: currentDate
     }
@@ -324,7 +328,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 18053
       },
       sell: {
         quantity: 56,
@@ -333,7 +338,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 48053
       },
       last_update: '2014-11-17T04:07:00+0000'
     }
@@ -355,7 +361,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 18053
       },
       sell: {
         quantity: 56,
@@ -364,7 +371,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 48053
       },
       last_update: currentDate
     }
@@ -383,7 +391,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 18053
       },
       sell: {
         quantity: 56,
@@ -392,7 +401,8 @@ describe('workers > item worker', () => {
           time: '2014-11-17T04:07:00+0000',
           quantity: 0,
           price: 0
-        }
+        },
+        last_known: 48053
       },
       last_update: '2014-11-17T04:07:00+0000'
     }
@@ -414,7 +424,8 @@ describe('workers > item worker', () => {
           time: currentDate,
           quantity: -50,
           price: 100
-        }
+        },
+        last_known: 18153
       },
       sell: {
         quantity: 66,
@@ -423,9 +434,211 @@ describe('workers > item worker', () => {
           time: currentDate,
           quantity: 10,
           price: -50
-        }
+        },
+        last_known: 48003
       },
       last_update: currentDate
+    }
+
+    let x = worker.__get__('transformPrices')(itemInput, priceInput)
+    expect(x).to.deep.equal(expectedOutput)
+  })
+
+  it('updates the crafting price if the item has crafting information', () => {
+    let currentDate = worker.__get__('isoDate')()
+    let itemInput = {
+      buy: {
+        quantity: 156,
+        price: 18053,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 18053
+      },
+      sell: {
+        quantity: 56,
+        price: 48053,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 48053
+      },
+      last_update: '2014-11-17T04:07:00+0000',
+      crafting: {
+        buy: 10000
+      }
+    }
+    let priceInput = {
+      buys: {
+        quantity: 106,
+        unit_price: 18153
+      },
+      sells: {
+        quantity: 66,
+        unit_price: 48003
+      }
+    }
+    let expectedOutput = {
+      buy: {
+        quantity: 106,
+        price: 18153,
+        last_change: {
+          time: currentDate,
+          quantity: -50,
+          price: 100
+        },
+        last_known: 18153
+      },
+      sell: {
+        quantity: 66,
+        price: 48003,
+        last_change: {
+          time: currentDate,
+          quantity: 10,
+          price: -50
+        },
+        last_known: 48003
+      },
+      last_update: currentDate,
+      craftingProfit: 30803
+    }
+
+    let x = worker.__get__('transformPrices')(itemInput, priceInput)
+    expect(x).to.deep.equal(expectedOutput)
+  })
+
+  it('keeps the last known price if the current price gets set to 0', () => {
+    let currentDate = worker.__get__('isoDate')()
+    let itemInput = {
+      buy: {
+        quantity: 156,
+        price: 200,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 100
+      },
+      sell: {
+        quantity: 56,
+        price: 200,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 48053
+      },
+      last_update: '2014-11-17T04:07:00+0000',
+      crafting: {
+        buy: 10000
+      }
+    }
+    let priceInput = {
+      buys: {
+        quantity: 106,
+        unit_price: 0
+      },
+      sells: {
+        quantity: 66,
+        unit_price: 0
+      }
+    }
+    let expectedOutput = {
+      buy: {
+        quantity: 106,
+        price: 0,
+        last_change: {
+          time: currentDate,
+          quantity: -50,
+          price: -200
+        },
+        last_known: 200
+      },
+      sell: {
+        quantity: 66,
+        price: 0,
+        last_change: {
+          time: currentDate,
+          quantity: 10,
+          price: -200
+        },
+        last_known: 200
+      },
+      last_update: currentDate,
+      craftingProfit: -10000
+    }
+
+    let x = worker.__get__('transformPrices')(itemInput, priceInput)
+    expect(x).to.deep.equal(expectedOutput)
+  })
+
+  it('keeps the last known price if there is no current price', () => {
+    let currentDate = worker.__get__('isoDate')()
+    let itemInput = {
+      buy: {
+        quantity: 156,
+        price: 0,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 100
+      },
+      sell: {
+        quantity: 56,
+        price: 0,
+        last_change: {
+          time: '2014-11-17T04:07:00+0000',
+          quantity: 0,
+          price: 0
+        },
+        last_known: 48053
+      },
+      last_update: '2014-11-17T04:07:00+0000',
+      crafting: {
+        buy: 10000
+      }
+    }
+    let priceInput = {
+      buys: {
+        quantity: 106,
+        unit_price: 0
+      },
+      sells: {
+        quantity: 66,
+        unit_price: 0
+      }
+    }
+    let expectedOutput = {
+      buy: {
+        quantity: 106,
+        price: 0,
+        last_change: {
+          time: currentDate,
+          quantity: -50,
+          price: 0
+        },
+        last_known: 100
+      },
+      sell: {
+        quantity: 66,
+        price: 0,
+        last_change: {
+          time: currentDate,
+          quantity: 10,
+          price: 0
+        },
+        last_known: 48053
+      },
+      last_update: currentDate,
+      craftingProfit: -10000
     }
 
     let x = worker.__get__('transformPrices')(itemInput, priceInput)

--- a/tests/workers/recipe.spec.js
+++ b/tests/workers/recipe.spec.js
@@ -38,11 +38,13 @@ describe('workers > recipe worker', () => {
     await mongo.collection('items').insert({id: 1, name: 'placeholder item'})
     await worker.initialize()
 
-    expect(executeMock.callCount).to.equal(1)
+    expect(executeMock.callCount).to.equal(2)
     expect(executeMock.args[0][0].name).to.equal('loadRecipeList')
+    expect(executeMock.args[1][0].name).to.equal('updateCraftingPrices')
 
-    expect(scheduleMock.callCount).to.equal(1)
+    expect(scheduleMock.callCount).to.equal(2)
     expect(scheduleMock.args[0][1].name).to.equal('loadRecipeList')
+    expect(scheduleMock.args[1][1].name).to.equal('updateCraftingPrices')
   })
 
   it('initializes correctly with data', async () => {
@@ -52,8 +54,9 @@ describe('workers > recipe worker', () => {
 
     expect(executeMock.callCount).to.equal(0)
 
-    expect(scheduleMock.callCount).to.equal(1)
+    expect(scheduleMock.callCount).to.equal(2)
     expect(scheduleMock.args[0][1].name).to.equal('loadRecipeList')
+    expect(scheduleMock.args[1][1].name).to.equal('updateCraftingPrices')
   })
 
   it('loads the recipe list correctly', async () => {
@@ -81,6 +84,65 @@ describe('workers > recipe worker', () => {
     expect(items).to.deep.equal([{id: 1, craftable: true}, {id: 9001, craftable: false}])
 
     worker.__set__('loadCustomRecipes', tmp)
+  })
+
+  it('updates the crafting prices correctly', async () => {
+    await mongo.collection('recipe-trees').insert([
+      {
+        id: 30686,
+        quantity: 1,
+        output: 1,
+        components: [
+          {id: 46742, quantity: 1},
+          {id: 29170, quantity: 1, components: [{id: 46747, quantity: 1}]},
+          {id: 12324, quantity: 1}
+        ]
+      },
+      {
+        id: 1,
+        quantity: 1,
+        output: 1,
+        components: [
+          {id: 12324, quantity: 1}
+        ]
+      }
+    ])
+
+    await mongo.collection('items').insert([
+      {id: 30686},
+      {id: 1},
+      {id: 46742, tradable: true, buy: {price: 100}, sell: {price: 200}},
+      {id: 29170, tradable: true, buy: {price: 500}, sell: {price: 1000}},
+      {id: 12324, tradable: true, buy: {price: 10000}, sell: {price: 20000}}
+    ])
+
+    await worker.updateCraftingPrices()
+
+    let legendary = await mongo.collection('items').find({id: 30686}, {_id: 0}).limit(1).next()
+    expect(legendary).to.deep.equal({
+      id: 30686,
+      crafting: {
+        buy: 258,
+        buyNoDaily: 258,
+        sell: 358,
+        sellNoDaily: 358
+      },
+      craftingWithoutPrecursors: {
+        buy: 608,
+        buyNoDaily: 608,
+        sell: 1208,
+        sellNoDaily: 1208
+      }
+    })
+
+    let nonLegendary = await mongo.collection('items').find({id: 1}, {_id: 0}).limit(1).next()
+    expect(nonLegendary).to.deep.equal({
+      id: 1,
+      crafting: {
+        buy: 8,
+        sell: 8
+      }
+    })
   })
 
   it('loads and filters custom recipes correctly', async () => {


### PR DESCRIPTION
This is a breaking change, since it changes the nested recipes. Needed for [the new recipe calculation](https://github.com/gw2efficiency/recipe-calculation).

- [X] Fix the bug with wrong quantities if a top level recipe has > 1 output
- [X] Don't multiply the quantities anymore, this should be handled by the consumer now
- [X] Add crafting prices and crafting profit to the item
- [x] Add "last sell price"
- [x] Add tests