### PR TITLE
Add support for Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4"
   - "5"
 after_script: "./node_modules/.bin/codecov"
 branches:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "babel-polyfill": "^6.7.4",
     "chalk": "^1.1.1",
+    "cron-parser": "^2.0.2",
     "escape-string-regexp": "^1.0.5",
     "gw2e-async-promises": "^1.0.2",
     "gw2e-gw2api-client": "^1.0.0",


### PR DESCRIPTION
This module should be able to run with node 4 as well, but some dependencies were failing due to npm v3 using a different way or resolving dependencies. Let's make sure that doesn't happen again. :)

---

Reference: #28